### PR TITLE
Fix/amber process restart

### DIFF
--- a/meze/sofra.py
+++ b/meze/sofra.py
@@ -257,6 +257,10 @@ class ColdMeze(Meze):
         config_options = {"cut": recipe.nb_cutoff,
                           "ntpr": 1000}
         
+        if restart:
+            config_options["irest"] = 1
+            config_options["ntx"] = 5
+
         if position_restraints:
             config_options["restraintmask"] = self._build_restraint_mask(position_restraints)
         
@@ -275,7 +279,6 @@ class ColdMeze(Meze):
             if recipe.start_temperature != recipe.end_temperature:
                 temperature = None
             protocol = bss.Protocol.Equilibration(
-                restart=restart,
                 timestep=dt,
                 runtime=runtime,
                 temperature_start=start_temperature,
@@ -288,7 +291,6 @@ class ColdMeze(Meze):
         elif protocol_type == "npt":
             config_options["barostat"] = recipe.barostat
             protocol = bss.Protocol.Equilibration(
-                restart=restart,
                 timestep=dt,
                 runtime=runtime,
                 temperature=temperature,

--- a/tests/test_equil.py
+++ b/tests/test_equil.py
@@ -8,7 +8,7 @@ cold_meze = ColdMeze.from_files(
     topology=f"{input_dir}/vim2_solv.prmtop",
     coordinates=f"{input_dir}/vim2_solv.inpcrd",
     group_name="vim2_wat",
-    path_to_executable=os.path.join(
+    path_to_engine=os.path.join(
         os.environ["AMBERHOME"], "bin", "pmemd.cuda"
     )
 )


### PR DESCRIPTION
Manually add configuration options to `run` to enable a restart run for the amber process 