### PR TITLE
fix: reduce default timestep for qmmm production runs

### DIFF
--- a/meze/sofra.py
+++ b/meze/sofra.py
@@ -837,7 +837,7 @@ class HotQuantumMeze(QuantumMeze):
             system: Optional[bssSystem] = None,
             process_name: Optional[str] = "qm-meze-run",
             nb_cutoff: Optional[float] = None,
-            timestep: Optional[Union[float, bssTime]] = None,
+            timestep: Optional[Union[float, bssTime]] = 0.001,
             runtime: Optional[Union[float, bssTime]] = None,
             temperature: Optional[Union[float, bssTemperature]] = 300,
             pressure: Optional[Union[float, bssPressure]] = 1,


### PR DESCRIPTION
- reduced timestep for QM/MM production runs from 0.002 ps to 0.001 ps