### PR TITLE
fix/sofra class update json

### DIFF
--- a/examples/hybrid_model/vim2/average_hybrid_model_charges.py
+++ b/examples/hybrid_model/vim2/average_hybrid_model_charges.py
@@ -9,6 +9,7 @@ EXAMPLES_DIR = REPO_ROOT / "examples"
 DATA_DIR = REPO_ROOT / "data"
 
 project_dir = DATA_DIR
+project_dir = "/Users/af25016/projects/hybrid_model/"
 
 system_name = "vim2"
 

--- a/examples/hybrid_model/vim2/average_hybrid_model_charges.py
+++ b/examples/hybrid_model/vim2/average_hybrid_model_charges.py
@@ -9,7 +9,6 @@ EXAMPLES_DIR = REPO_ROOT / "examples"
 DATA_DIR = REPO_ROOT / "data"
 
 project_dir = DATA_DIR
-project_dir = "/Users/af25016/projects/hybrid_model/"
 
 system_name = "vim2"
 

--- a/meze/sofra.py
+++ b/meze/sofra.py
@@ -2671,7 +2671,6 @@ class Sofra:
                 mezes[ligand_name] = Meze.load(entry["pickle_file"])
             except KeyError:
                 log.error(f"Could not find pickle file for {ligand_name}: ")
-                log.error(entry["pickle_file"])
         if not mezes:
             message = f"Could not find any mezes in {sofra_file}"
             log.error(message)

--- a/meze/sofra.py
+++ b/meze/sofra.py
@@ -2664,15 +2664,21 @@ class Sofra:
             raise FileNotFoundError(message)
         with open(sofra_file, "r") as file:
             sofra_contents = json.load(file)
+        mezes = {}
         for ligand_name, entry in sofra_contents.items():
             
             try:
-                mezes = {
-                    ligand_name: Meze.load(entry["pickle_file"])
-                }
+                mezes[ligand_name] = Meze.load(entry["pickle_file"])
             except KeyError:
-                log.error(f"Could not find pickle file for {ligand_name}")
-
+                log.error(f"Could not find pickle file for {ligand_name}: ")
+                log.error(entry["pickle_file"])
+        if not mezes:
+            message = f"Could not find any mezes in {sofra_file}"
+            log.error(message)
+            raise RuntimeError
+        if len(mezes) == 1:
+            message = f"Found only one meze in {sofra_file}. Are you sure you wish to continue?"
+            log.warning(message)
         return cls(mezes=mezes, sofra_file=sofra_file, sofra_contents=sofra_contents)
 
 
@@ -2861,7 +2867,12 @@ class Sofra:
             for old_file in files_to_copy:
                 file = os.path.basename(old_file)
                 new_file = os.path.join(new_parameterisation_directories[i], file)
-                shutil.copy(old_file, new_file)
+                try:
+                    shutil.copy(old_file, new_file)
+                except shutil.SameFileError as e:
+                    log.warning(e)
+                    log.info(f"Keeping {old_file}")
+                    
                 if ".RST" in os.path.splitext(file):
                     new_restraints = new_file
                 if "tleap" in file:
@@ -2946,7 +2957,11 @@ class Sofra:
             if solvated.tleap_input_file:
                 self.sofra_contents[ligand_name]["tleap_input_file"] = solvated.tleap_input_file                                                          
             if solvated.restraint_file:
-                self.sofra_contents[ligand_name]["restraint_file"] = solvated.restraint_file      
+                self.sofra_contents[ligand_name]["restraint_file"] = solvated.restraint_file 
+            if os.path.isfile(solvated.topology):
+                self.sofra_contents[ligand_name]["topology"] = solvated.topology
+            if os.path.isfile(solvated.coordinates):
+                self.sofra_contents[ligand_name]["coordinates"] = solvated.coordinates
 
             solvated_mezes.append(solvated)                                                        
                                                                                                                                                             


### PR DESCRIPTION
## Summary

   - Fix `Sofra.from_file` where `mezes` dict was being overwritten on each loop iteration (colon-instead-of-equals bug), causing only the last entry to be loaded
   - Add guards for empty or single-entry sofra files with appropriate error/warning messages
   - Handle `shutil.SameFileError` gracefully when source and destination are the same file during charge averaging
   - Write `topology` and `coordinates` fields to the sofra JSON after solvation in `build_average_charges`

   ## Test plan

   - [ ] Run `average_charges.py` with a sofra JSON containing multiple ligand entries and verify all mezes are loaded
   - [ ] Verify the sofra JSON is updated with `topology` and `coordinates` after `build_average_charges` completes
   - [ ] Confirm no crash when source and destination files are the same during file copy

   🤖 Generated with [Claude Code](https://claude.com/claude-code)