### PR TITLE
refactor: add a bound dir for equilibrations

### DIFF
--- a/examples/hybrid_model/vim2/heat_meze.py
+++ b/examples/hybrid_model/vim2/heat_meze.py
@@ -29,7 +29,7 @@ solvated_meze.recipe.path_to_engine = os.path.join("AMBERHOME", "bin", "sander")
 
 print(solvated_meze)
 
-equil_dir = os.path.join(project_dir, "equilibration", "hybrid_model", system_name, f"{ligand_name}", f"repeat_{repeat}")
+equil_dir = os.path.join(project_dir, "equilibration", "hybrid_model", system_name, "bound", f"{ligand_name}", f"repeat_{repeat}")
 
 os.makedirs(equil_dir, exist_ok=True)
 

--- a/examples/hybrid_model/vim2/production.py
+++ b/examples/hybrid_model/vim2/production.py
@@ -10,7 +10,7 @@ system_name = "vim2"
 
 # set ColdMezeRecipe including model (i.e. metal params), ligand(?)
 
-with open(f"{project_dir}/inputs/model_0/protein/{system_name}/model_0_recipe.json", "r") as file:
+with open(f"{project_dir}/inputs/hybrid_model/protein/{system_name}/hybrid_model_recipe.json", "r") as file:
     json_recipe = json.load(file)
 
 json_recipe["path_to_engine"] = os.path.join(
@@ -21,7 +21,7 @@ json_recipe["path_to_engine"] = os.path.join(
 json_recipe["runtime"] = 150
 json_recipe["dt"] = 0.002
 
-equil_dir = f"{project_dir}/equilibration/model_0/{ligand_name}/repeat_{repeat}/"
+equil_dir = f"{project_dir}/equilibration/hybrid_model/bound/{ligand_name}/repeat_{repeat}/"
 
 hot_meze = HotMeze.from_files(
     recipe=HotMezeRecipe(**json_recipe),
@@ -30,7 +30,7 @@ hot_meze = HotMeze.from_files(
     restraint_file=f"{equil_dir}/restraints.RST"
 ) 
 
-production_dir = os.path.join(project_dir, "outputs", "model_0", f"{ligand_name}", f"repeat_{repeat}")
+production_dir = os.path.join(project_dir, "outputs", "hybrid_model", f"{ligand_name}", f"repeat_{repeat}")
 os.makedirs(production_dir, exist_ok=True)
 
 hot_meze.run(

--- a/examples/model_0/l1/heat_meze.py
+++ b/examples/model_0/l1/heat_meze.py
@@ -26,7 +26,7 @@ solvated_meze = ColdMeze.from_files(
     ligand_resname="MOL"
 )
 
-equil_dir = os.path.join(project_dir, "equilibration", "model_0", system_name, f"{ligand_name}", f"repeat_{repeat}")
+equil_dir = os.path.join(project_dir, "equilibration", "model_0", system_name, "bound", f"{ligand_name}", f"repeat_{repeat}")
 
 os.makedirs(equil_dir, exist_ok=True)
 

--- a/examples/model_0/vim2/heat_meze.py
+++ b/examples/model_0/vim2/heat_meze.py
@@ -32,7 +32,7 @@ solvated_meze = ColdMeze.from_files(
     ligand_resname="MOL"
 )
 
-equil_dir = os.path.join(project_dir, "equilibration", "model_0", system_name, f"{ligand_name}", f"repeat_{repeat}")
+equil_dir = os.path.join(project_dir, "equilibration", "model_0", system_name, "bound", f"{ligand_name}", f"repeat_{repeat}")
 
 os.makedirs(equil_dir, exist_ok=True)
 

--- a/examples/model_0/vim2/production.py
+++ b/examples/model_0/vim2/production.py
@@ -21,7 +21,7 @@ json_recipe["path_to_engine"] = os.path.join(
 json_recipe["runtime"] = 150
 json_recipe["dt"] = 0.002
 
-equil_dir = f"{project_dir}/equilibration/model_0/{ligand_name}/repeat_{repeat}/"
+equil_dir = f"{project_dir}/equilibration/model_0/bound/{ligand_name}/repeat_{repeat}/"
 
 hot_meze = HotMeze.from_files(
     recipe=HotMezeRecipe(**json_recipe),


### PR DESCRIPTION
## Summary

- added a `bound` directory to all `heat_meze.py` scripts

## Test plan
- [ ] model 0: check `equilibration/bound` directories exist
- [ ] hybrid model: check `equilibration/bound` directories exist

